### PR TITLE
Fix asynchronous usage in TomTom alerts

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -529,7 +529,7 @@ async function fetchTomTomTrafficFixed() {
     const alerts = [];
     
     if (response.data?.tm?.poi) {
-      response.data.tm.poi.forEach(incident => {
+      response.data.tm.poi.forEach(async incident => {
         // Process incidents into your alert format
         const lat = incident.p?.y;
         const lng = incident.p?.x;


### PR DESCRIPTION
## Summary
- mark callback as async so that `await` is valid inside `forEach`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68416d57ecb0832aa647272e5804b809